### PR TITLE
Remove extra quote mark on whitelisted hosts

### DIFF
--- a/tasks/firewall.yml
+++ b/tasks/firewall.yml
@@ -34,7 +34,7 @@
 
 - name: UFW | Allow whitelisted hosts
   ufw: rule=allow src={{ item }} insert=1
-  with_items: "{{ firewall_whitelisted_hosts }}""
+  with_items: "{{ firewall_whitelisted_hosts }}"
 
 - name: UFW | Deny blacklisted hosts
   ufw: rule=deny src={{ item }} insert=2


### PR DESCRIPTION
The extra quote mark was causing an issue for me when trying to use this with Ansible 2.
